### PR TITLE
Allow use of plugin with a Jenkins instance running under an arbitrary user.

### DIFF
--- a/etc/support/killThemAll.sh
+++ b/etc/support/killThemAll.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # kill them all and let God sort them out
-ssh -x $1 "ps -u hudson -o pid,args | grep -v -e .*slave.jar$ | grep -o -E ^[0-9,' '][0-9]+ | xargs kill -9"
+ssh -x $1 "ps -u ${USER:-hudson} -o pid,args | grep -v -e .*slave.jar$ | grep -o -E ^[0-9,' '][0-9]+ | xargs kill -9"


### PR DESCRIPTION
I installed a version of this plugin on a new lab where the Jenkins instance is run under user jenkins. This plugin's attempt to kill any leftover processes failed as the user hudson was not defined on the system. I'm suspecting that using $USER with the bash script will work in most cases to allow leftover processes to be killed no matter what the username. 