### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .settings
 target
 work
+.idea

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-Jenkins/Hudson SmartFrog plugin
+Jenkins SmartFrog plugin
 
-http://www.jenkins-ci.org/
+http://www.jenkins.io/
 
 http://www.smartfrog.org/
-
-

--- a/src/main/resources/builder/smartfrog/SmartFrogAction/action.jelly
+++ b/src/main/resources/builder/smartfrog/SmartFrogAction/action.jelly
@@ -11,7 +11,7 @@
         </j:if>
     </l:tasks>
     <j:if test="${!it.building}">
-        <l:task icon="images/24x24/edit-delete.png" href="${h.getActionUrl(it.url,action)}/confirmDelete" title="${%Delete} ${action.displayName}"
+        <l:task icon="icon-edit-delete icon-md" href="${h.getActionUrl(it.url,action)}/confirmDelete" title="${%Delete} ${action.displayName}"
             permission="${it.DELETE}" />
     </j:if>
 </j:jelly>

--- a/src/main/resources/builder/smartfrog/SmartFrogAction/index.jelly
+++ b/src/main/resources/builder/smartfrog/SmartFrogAction/index.jelly
@@ -10,7 +10,7 @@
       </h1>
       <l:rightspace>
         <a href="consoleText">
-          <img src="${imagesURL}/24x24/document.gif" alt="" />View as plain text
+          <l:icon class="icon-document icon-md" />View as plain text
         </a>
       </l:rightspace>
       <j:choose>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @rhusar 
Thanks in advance!